### PR TITLE
Switch Github and Gitab URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 You want to give a hand? Thank you very much!
 
-:warning: This repository is hosted on gitlab.com. It is only mirrored on Github. If you want to contribute, please check [here](https://gitlab.com/KillianKemps/kamosocial)
+:warning: This repository is hosted on github.com. It is only mirrored on Gitlab. If you want to contribute, please check [here](https://github.com/KillianKemps/kamosocial)
 
 ## Installation
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <ul class="conditions">
     <li><%= link_to t("footer.privacy_policy"), privacy_policy_path %></li><!--
     --><li><%= link_to t("footer.credits"), credits_path %></li><!--
-    --><li><a href="https://gitlab.com/KillianKemps/kamosocial"><%=t("footer.opensource") %></a></li>
+    --><li><a href="https://github.com/KillianKemps/kamosocial"><%=t("footer.opensource") %></a></li>
   </ul>
   <ul class="author">
     <li><%=t 'footer.made_with_love' %></li><!--


### PR DESCRIPTION
Gitlab has better features than Github.

However, there are more people connected to Github and pages like "Explore" and the activity feed help to get people to contribute.

It may switch again later, but I think that to attract contributors it is better to have the main repo on Github for the moment.