### PR TITLE
Change email provider to Mailjet

### DIFF
--- a/app/views/privacy/index.html.erb
+++ b/app/views/privacy/index.html.erb
@@ -35,6 +35,12 @@
     </address>
   </p>
 
+  <h2><%=t 'privacy.email.title' %></h2>
+  <p>
+    <%=t 'privacy.email.provider_html' %><br>
+    <%=t 'privacy.email.gdpr_html' %><br>
+  </p>
+
   <h2><%=t 'privacy.personal_data_process.title' %></h2>
   <p><%=t 'privacy.personal_data_process.protection' %></p>
   <p><%=t 'privacy.personal_data_process.rights' %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,13 +36,13 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    address: "mail.gandi.net",
+    address: ENV["MAILER_ADDRESS"],
     port: 587,
-    domain: ENV["EMAIL_DOMAIN"],
+    domain: ENV["MAILER_DOMAIN"],
     authentication: "plain",
     enable_starttls_auto: true,
-    user_name: ENV["EMAIL_USERNAME"],
-    password: ENV["EMAIL_PASSWORD"]
+    user_name: ENV["MAILER_USERNAME"],
+    password: ENV["MAILER_PASSWORD"]
   }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,13 +72,13 @@ Rails.application.configure do
   config.action_mailer.default :charset => "utf-8"
 
   config.action_mailer.smtp_settings = {
-    address: "mail.gandi.net",
+    address: ENV["MAILER_ADDRESS"],
     port: 587,
-    domain: ENV["EMAIL_DOMAIN"],
+    domain: ENV["MAILER_DOMAIN"],
     authentication: "plain",
     enable_starttls_auto: true,
-    user_name: ENV["EMAIL_USERNAME"],
-    password: ENV["EMAIL_PASSWORD"]
+    user_name: ENV["MAILER_USERNAME"],
+    password: ENV["MAILER_PASSWORD"]
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/locales/privacy/en.yml
+++ b/config/locales/privacy/en.yml
@@ -47,6 +47,10 @@ en:
       hoster: "The site is hosted by"
       servers: "Servers are located in Europe."
       address: "Hosting provider address:"
+    email:
+      title: "Sending emails"
+      provider_html: "Emails are sent by <a href=\"https://en.mailjet.com/\">Mailjet</a>"
+      gdpr_html: "This French provider has declared himself as compliant with the <a href=\"https://en.mailjet.com/gdpr/\">GDPR</a>. In order to send email, the provider processes Kamo.social users email addresses."
     personal_data_process:
       title: "Processing of personal data"
       protection: "The European Directive of 24 October 1995, the French law 78-87 of 6 January 1978, the French law 2004-801 of 6 August 2004 and the article L-226-13 of the French Penal Code protect all personal data."

--- a/config/locales/privacy/fr.yml
+++ b/config/locales/privacy/fr.yml
@@ -47,6 +47,10 @@ fr:
       hoster: "L'hébergement du site est assuré par"
       servers: "Les serveurs sont situés en Europe."
       address: "Adresse de l'hébergeur :"
+    email:
+      title: "Envoi d'email"
+      provider_html: "L'envoi des emails est assuré par <a href=\"https://fr.mailjet.com/\">Mailjet</a>"
+      gdpr_html: "Le prestataire est français et se dit conforme au <a href=\"https://fr.mailjet.com/rgpd/\">RGPD</a>. Afin d'envoyer des emails, ce prestataire traite les adresses email des utilisateurs de Kamo.social."
     personal_data_process:
       title: "Traitement des données à caractère personnel"
       protection: "La directive Européenne du 24 Octobre 1995, la loi française 78-87 du 6 janvier 1978, la loi française 2004-801 du 6 août 2004 ainsi que l'article L-226-13 du code pénal français protègent l'ensemble des données personnelles."


### PR DESCRIPTION
## Description
- Add mailer environment variable
- Add email provider to privacy policy

## Reason
Allow to use an external email provider. In this case, changing to the French Mailjet in order to send more emails and have a better email reputation.